### PR TITLE
Add wabi-sabi mode setting

### DIFF
--- a/app/controllers/draft_controller.rb
+++ b/app/controllers/draft_controller.rb
@@ -43,6 +43,7 @@ class DraftController < ApplicationController
       options[:status] = :bad_request unless @post.valid?
     when :review
       @post.published_at = Time.zone.now
+      @post.snapshot_images! # Wabi-sabi mode: capture current photo/cover for historical display
       @post.save!
       @post.send_newsletter
       @post.account.update(pinned_post: @post)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,7 +25,7 @@ class PagesController < ApplicationController
   private
 
   def account_params
-    params.require(:account).permit(:name, :slug, :photo, :cover, :description, :accent_color, :code)
+    params.require(:account).permit(:name, :slug, :photo, :cover, :description, :accent_color, :code, :wabi_sabi_mode)
   end
 
   def set_account

--- a/app/controllers/public_posts_controller.rb
+++ b/app/controllers/public_posts_controller.rb
@@ -23,7 +23,10 @@ class PublicPostsController < ApplicationController
   end
 
   def og_image
-    png = Rails.cache.fetch("post-#{@post.id}-#{@post.updated_at.to_i}-og-img-v0") do
+    # Include wabi_sabi_mode in cache key so toggling the setting busts the cache
+    # Also include account.updated_at since images may have changed
+    cache_key = "post-#{@post.id}-#{@post.updated_at.to_i}-#{@account.updated_at.to_i}-wabi-#{@account.wabi_sabi_mode}-og-img-v1"
+    png = Rails.cache.fetch(cache_key) do
       generate_og_image
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,6 +9,10 @@ class Post < ApplicationRecord
 
   has_many :email_messages, dependent: :destroy
 
+  # Wabi-sabi mode: store the photo and cover blob IDs at publish time
+  belongs_to :published_photo_blob, class_name: 'ActiveStorage::Blob', optional: true
+  belongs_to :published_cover_blob, class_name: 'ActiveStorage::Blob', optional: true
+
   has_rich_text :body
 
   validates :subject, presence: true, length: { maximum: 255 }
@@ -60,6 +64,40 @@ class Post < ApplicationRecord
     port = Rails.env.production? ? nil : ':3000'
     domain_host = account.host(show_unverified: show_unverified)
     "#{scheme}://#{domain_host}#{port}/posts/#{slug}"
+  end
+
+  # Wabi-sabi mode: snapshot the current account photo and cover when publishing
+  def snapshot_images!
+    self.published_photo_blob = account.photo.blob if account.photo.attached?
+    self.published_cover_blob = account.cover.blob if account.cover.attached?
+  end
+
+  # Get the appropriate photo for display based on wabi_sabi_mode
+  # Returns an ActiveStorage attachment-like object or nil
+  def display_photo
+    return account.photo unless account.wabi_sabi_mode?
+    return account.photo unless published_photo_blob.present?
+
+    published_photo_blob
+  end
+
+  # Get the appropriate cover for display based on wabi_sabi_mode
+  # Returns an ActiveStorage attachment-like object or nil
+  def display_cover
+    return account.cover unless account.wabi_sabi_mode?
+    return account.cover unless published_cover_blob.present?
+
+    published_cover_blob
+  end
+
+  # Check if display_photo returns a blob (historical) vs attachment (current)
+  def display_photo_is_blob?
+    account.wabi_sabi_mode? && published_photo_blob.present?
+  end
+
+  # Check if display_cover returns a blob (historical) vs attachment (current)
+  def display_cover_is_blob?
+    account.wabi_sabi_mode? && published_cover_blob.present?
   end
 
   private

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -129,6 +129,20 @@
       </div>
     </div>
 
+    <div class="pt-6 border-t border-gray-200">
+      <div class="flex items-start">
+        <div class="flex items-center h-5">
+          <%= f.check_box :wabi_sabi_mode, class: 'h-4 w-4 rounded border-gray-300 text-accent focus:ring-accent' %>
+        </div>
+        <div class="ml-3">
+          <%= f.label :wabi_sabi_mode, 'Wabi-sabi mode', class: 'form-label' %>
+          <div class="form-description">
+            Show posts with your photo and cover image from the time they were published, rather than your current images. Embraces the beauty of change over time.
+          </div>
+        </div>
+      </div>
+    </div>
+
     <%= render :partial => "shared/primary_button_loading", locals: { label: 'Publish', classes: " mt-12" } %>
   </div>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -4,9 +4,9 @@ disabled = defined?(:disabled) ? disabled : false
 <div class="w-full bg-white min-h-screen flex flex-col">
   <div class="flex-grow">
     <div>
-      <%= render "public_pages/page/cover", picture: post.account.cover, alt: "Cover photo for #{post.account.name}", classes: "h-36 lg:h-60" %>
+      <%= render "public_pages/page/cover", picture: post.display_cover, alt: "Cover photo for #{post.account.name}", classes: "h-36 lg:h-60" %>
     </div>
-    <%= render :partial => 'public_pages/page/profile_photo', locals: {account: post.account} %>
+    <%= render :partial => 'public_pages/page/profile_photo', locals: {account: post.account, photo: post.display_photo} %>
     <%= render :partial => 'public_pages/page/title', locals: {title: post.subject } %>
     <div class="public-page-container pt-2">
       <%= render :partial => 'posts/byline', locals: {post: post } %>

--- a/app/views/public_pages/page/_cover.html.erb
+++ b/app/views/public_pages/page/_cover.html.erb
@@ -1,11 +1,14 @@
 <%
 simple_mode = defined?(:simple_mode) ? simple_mode : false
+# Support both ActiveStorage attachments and raw blobs (for wabi-sabi mode)
+picture_is_blob = picture.is_a?(ActiveStorage::Blob)
+picture_attached = picture_is_blob || picture.attached?
 %>
-<% if picture.attached? %>
+<% if picture_attached %>
   <% widths = [400, 800, 1600, 3200, 6400 ] %>
 
   <picture>
-    <% unless simple_mode %>
+    <% unless simple_mode || picture_is_blob %>
       <source
         type="image/webp"
         srcset="
@@ -20,7 +23,7 @@ simple_mode = defined?(:simple_mode) ? simple_mode : false
       class="object-cover w-full bg-white <%= classes %>"
       src="<%= cdn_proxy_url(picture) %>"
       alt="<%= alt %>"
-      <% unless simple_mode %>
+      <% unless simple_mode || picture_is_blob %>
       srcset="
           <% widths.each do |width| %>
             <%= cdn_proxy_url(picture.variant(resize_to_limit: [width, nil])) %> <%= width %>w,

--- a/app/views/public_pages/page/_profile_photo.html.erb
+++ b/app/views/public_pages/page/_profile_photo.html.erb
@@ -1,8 +1,21 @@
+<%
+# Support optional photo parameter for wabi-sabi mode (can be a blob or attachment)
+photo_to_display = defined?(photo) && photo.present? ? photo : account.photo
+photo_is_blob = photo_to_display.is_a?(ActiveStorage::Blob)
+photo_attached = photo_is_blob || photo_to_display.attached?
+%>
 <div class="flex items-center justify-between public-page-container">
   <div class="-mt-16">
     <a class="flex" href="/">
-      <% if account.photo.attached? %>
-        <%= render "shared/square_picture_variants", picture: account.photo, size: 144, classes: "h-32 w-32 rounded-full ring-4 ring-white sm:h-36 sm:w-36 bg-white", alt: account.name %>
+      <% if photo_attached %>
+        <% if photo_is_blob %>
+          <%# Raw blob from wabi-sabi mode - display without variants %>
+          <img class="h-32 w-32 rounded-full ring-4 ring-white sm:h-36 sm:w-36 bg-white object-cover"
+               src="<%= cdn_proxy_url(photo_to_display) %>"
+               alt="<%= account.name %>" />
+        <% else %>
+          <%= render "shared/square_picture_variants", picture: photo_to_display, size: 144, classes: "h-32 w-32 rounded-full ring-4 ring-white sm:h-36 sm:w-36 bg-white", alt: account.name %>
+        <% end %>
       <% else %>
         <span class="inline-block w-32 h-32 overflow-hidden rounded-full bg-gray-075 ring-4 ring-white sm:h-36 sm:w-36">
           <svg class="w-full h-full text-gray-200" fill="currentColor" viewBox="0 0 24 24">

--- a/app/views/public_posts/og_image.html.erb
+++ b/app/views/public_posts/og_image.html.erb
@@ -1,15 +1,37 @@
+<%
+# Wabi-sabi mode: use historical images from publish time if available
+display_cover = post.display_cover
+display_photo = post.display_photo
+cover_is_blob = display_cover.is_a?(ActiveStorage::Blob)
+photo_is_blob = display_photo.is_a?(ActiveStorage::Blob)
+cover_attached = cover_is_blob || display_cover&.attached?
+photo_attached = photo_is_blob || display_photo&.attached?
 
+# Generate cover URL (with variant if attachment, without if blob)
+if cover_attached
+  cover_url = cover_is_blob ? cdn_proxy_url(display_cover) : cdn_proxy_url(display_cover.variant(convert: :webp, resize_to_limit: [1920, nil]).processed)
+else
+  cover_url = asset_path('postcards.jpg')
+end
+
+# Generate photo URL (with variant if attachment, without if blob)
+if photo_attached
+  photo_url = photo_is_blob ? cdn_proxy_url(display_photo) : cdn_proxy_url(display_photo.variant(resize_to_fill: [288, 288, { crop: :attention }]).processed)
+else
+  photo_url = asset_path('logo/icon.png')
+end
+%>
 <div class="w-full bg-white h-screen">
   <div class="">
     <img
       class="object-cover w-full h-36 bg-gray-050"
-        src="<%= account.cover.attached? ? cdn_proxy_url(account.cover.variant(convert: :webp, resize_to_limit: [1920, nil]).processed) : asset_path('postcards.jpg') %>"
+        src="<%= cover_url %>"
       />
     <div class="px-36 flex justify-between items-center">
       <div class="-mt-24">
         <div class="flex">
           <img class="h-48 w-48 rounded-full ring-4 ring-white"
-            src="<%= account.photo.attached? ? cdn_proxy_url(account.photo.variant(resize_to_fill: [288, 288, { crop: :attention }]).processed) : asset_path('logo/icon.png') %>"
+            src="<%= photo_url %>"
             />
         </div>
       </div>

--- a/db/migrate/20260204202536_add_wabi_sabi_mode.rb
+++ b/db/migrate/20260204202536_add_wabi_sabi_mode.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddWabiSabiMode < ActiveRecord::Migration[7.1]
+  def change
+    # Add wabi_sabi_mode setting to accounts
+    add_column :accounts, :wabi_sabi_mode, :boolean, default: false, null: false
+
+    # Add columns to posts to store the photo and cover blob IDs at publish time
+    # These reference the blob that was attached when the post was published
+    add_reference :posts, :published_photo_blob, foreign_key: { to_table: :active_storage_blobs }
+    add_reference :posts, :published_cover_blob, foreign_key: { to_table: :active_storage_blobs }
+  end
+end


### PR DESCRIPTION
## Summary
When enabled, posts display the account photo and cover image from the time they were published, rather than the current images. This embraces the beauty of change over time.

## Changes

### Database
- `accounts.wabi_sabi_mode` - boolean, default false
- `posts.published_photo_blob_id` - references active_storage_blobs
- `posts.published_cover_blob_id` - references active_storage_blobs

### Model (Post)
- `snapshot_images!` - captures current account photo/cover blob IDs
- `display_photo` / `display_cover` - returns historical or current image based on mode
- `display_photo_is_blob?` / `display_cover_is_blob?` - helper to detect blob vs attachment

### UI
- Toggle added to account edit page (Edit your page)
- Post views updated to use display methods

### Caching
- Post OG image cache key now includes `account.wabi_sabi_mode` and `account.updated_at`
- When toggling the setting, all post OG images will regenerate on next request
- Posts published before this feature (without stored blob IDs) fall back to current account images

## How it works
1. When a post is published, the current account photo and cover blob IDs are stored on the post
2. When wabi_sabi_mode is OFF: posts show current account images (existing behavior)
3. When wabi_sabi_mode is ON: posts show historical images from publish time
4. For posts without stored blob IDs: falls back to current images

## Notes
- Historical images display without responsive variants (srcset) since we only store the blob reference
- The main account page and post listing always show current images (wabi-sabi only affects individual post views)