### PR TITLE
Fix Render domain verification by calling verify endpoint

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -77,6 +77,10 @@ class Domain < ApplicationRecord
       return
     end
 
+    # Trigger DNS verification check with Render
+    Domain.render_service_request("/#{domain}/verify", Net::HTTP::Post)
+
+    # Then retrieve the updated status
     response = Domain.render_service_request("/#{domain}", Net::HTTP::Get)
 
     unless response.code == '200'


### PR DESCRIPTION
## Problem

The `update_verification_status` method was only doing a GET to check domain status, but never actually triggering DNS verification with Render.

## Solution

Added a POST call to the `/verify` endpoint before checking status, as documented in Render API:
https://api-docs.render.com/reference/refresh-custom-domain

The verify endpoint "manually triggers DNS verification for a custom domain."

## Changes

```ruby
# Trigger DNS verification check with Render
Domain.render_service_request("/#{domain}/verify", Net::HTTP::Post)

# Then retrieve the updated status
response = Domain.render_service_request("/#{domain}", Net::HTTP::Get)
```