### PR TITLE
Fix CI: Update Ruby version to 3.2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.0
+          ruby-version: 3.2.2
           bundler-cache: true
       - name: Install Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
The CI workflow was using Ruby 3.1.0 but Gemfile specifies 3.2.2, causing bundle install to fail.