### PR TITLE
Add zeitwerk:check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
           bundle exec rails db:migrate
           yarn --frozen-lockfile
           bundle exec rake assets:precompile
+      - name: Check Zeitwerk autoloading
+        run: bundle exec rails zeitwerk:check
       - name: Run unit tests (SOLO)
         run: bundle exec rails test:all
       - name: Run unit tests (MULTIUSER)


### PR DESCRIPTION
Adds `bundle exec rails zeitwerk:check` to catch autoloading/naming issues early.