### PR TITLE
Fix published post title not saving on edit

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,13 +12,14 @@
     <%= render 'shared/form_error_messages', object: f.object %>
 
     <div
+      data-controller="editable"
       <% unless post.published? %>
-        data-controller="editable" data-editable-autofocus-value="true"
+        data-editable-autofocus-value="true"
       <% end %>
       >
       <h1 contenteditable class="form-input-inline page-title"
         data-editable-target="content"
-        data-action="keyup->editable#changed keyup->editable#debouncedSave"
+        data-action="keyup->editable#changed<%= ' keyup->editable#debouncedSave' unless post.published? %>"
         data-placeholder="Title"
         placeholder="Title"
         ><%= post.subject %></h1>


### PR DESCRIPTION
The editable Stimulus controller was only attached for draft posts, so editing a published post's title never synced the contenteditable text to the hidden subject input. The form always submitted the original title.