### PR TITLE
Remove fbi.com from LOCALHOST_DOMAINS

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -39,7 +39,7 @@ class Domain < ApplicationRecord
     end
   end
 
-  LOCALHOST_DOMAINS = ['lvh.me', 'fuf.me', 'fbi.com'].freeze
+  LOCALHOST_DOMAINS = ['lvh.me', 'fuf.me'].freeze
   def self.localhost_domain?(domain)
     LOCALHOST_DOMAINS.each do |haystack|
       return true if (domain == haystack) || domain.ends_with?(".#{haystack}")


### PR DESCRIPTION
## Summary

Removes `fbi.com` from the `LOCALHOST_DOMAINS` array in `app/models/domain.rb`.

## Problem

`fbi.com` is a real domain (Federal Bureau of Investigation), not a localhost testing domain. The other entries (`lvh.me`, `fuf.me`) are legitimate localhost testing domains that resolve to 127.0.0.1, but `fbi.com` is an actual production website.

## Solution

Simply remove `fbi.com` from the array. The remaining two localhost domains are sufficient for development purposes.

Closes #25