### PR TITLE
Require payment for hosted (multi-user) Postcard

### DIFF
--- a/app/controllers/accounts/omniauth_callbacks_controller.rb
+++ b/app/controllers/accounts/omniauth_callbacks_controller.rb
@@ -17,7 +17,11 @@ module Accounts
     end
 
     def after_sign_in_path_for(resource_or_scope)
-      stored_location_for(resource_or_scope) || root_path
+      stored = stored_location_for(resource_or_scope)
+      return stored if stored.present?
+      return page_checkout_path(resource_or_scope) if resource_or_scope.is_a?(Account) && resource_or_scope.requires_payment?
+
+      root_path
     end
 
     private

--- a/app/controllers/accounts/registrations_controller.rb
+++ b/app/controllers/accounts/registrations_controller.rb
@@ -35,8 +35,11 @@ module Accounts
     end
 
     def after_sign_up_path_for(account)
-      # page_setup_index_path(account)
-      page_path(account)
+      if Rails.configuration.multiuser_mode
+        page_checkout_path(account)
+      else
+        page_path(account)
+      end
     end
 
     def update_resource(resource, params)

--- a/app/controllers/accounts/sessions_controller.rb
+++ b/app/controllers/accounts/sessions_controller.rb
@@ -27,7 +27,11 @@ module Accounts
     # end
 
     def after_sign_in_path_for(account)
-      stored_location_for(account) || root_path
+      stored = stored_location_for(account)
+      return stored if stored.present?
+      return page_checkout_path(account) if account.is_a?(Account) && account.requires_payment?
+
+      root_path
     end
   end
 end

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -6,7 +6,7 @@ class CheckoutController < ApplicationController
   before_action :redirect_in_solo
 
   def show
-    url = @account.checkout_url(page_setup_url(@account, :domain), page_url(@account))
+    url = @account.checkout_url(page_url(@account), page_url(@account))
     redirect_to url, status: :found, allow_other_host: true
   end
 

--- a/app/controllers/concerns/payment_required.rb
+++ b/app/controllers/concerns/payment_required.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PaymentRequired
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_payment
+  end
+
+  private
+
+  def require_payment
+    return unless current_account&.requires_payment?
+    return if params.key?(:session_id) # Just returned from Stripe, webhook pending
+
+    redirect_to page_checkout_path(current_account)
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,7 @@
 
 class PagesController < ApplicationController
   prepend_before_action :authenticate_account!
+  include PaymentRequired
   before_action :set_account
   layout 'dashboard'
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,6 +2,7 @@
 
 class PostsController < ApplicationController
   prepend_before_action :authenticate_account!
+  include PaymentRequired
   before_action :set_account_from_path
   before_action :set_post, only: %i[destroy edit update]
 

--- a/app/controllers/showcase_controller.rb
+++ b/app/controllers/showcase_controller.rb
@@ -2,6 +2,7 @@
 
 class ShowcaseController < ApplicationController
   prepend_before_action :authenticate_account!
+  include PaymentRequired
   before_action :set_account_from_path
   layout 'dashboard_container'
 

--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -4,6 +4,7 @@ require 'csv'
 
 class SubscribersController < ApplicationController
   prepend_before_action :authenticate_account!
+  include PaymentRequired
   before_action :set_account_from_path
   layout 'dashboard_container'
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -131,6 +131,20 @@ class Account < ApplicationRecord
     payment_processor&.subscribed?
   end
 
+  def requires_payment?
+    return false if Rails.configuration.solo_mode
+    return false if grandfathered?
+    return false if ever_subscribed?
+
+    !payment_processor&.subscribed?
+  end
+
+  def ever_subscribed?
+    Pay::Subscription.joins(:customer)
+      .where(pay_customers: { owner_type: 'Account', owner_id: id })
+      .exists?
+  end
+
   def unverified_domain?
     domains.each do |domain|
       return true unless domain.verified?
@@ -212,6 +226,7 @@ class Account < ApplicationRecord
       allow_promotion_codes: true,
       billing_address_collection: 'auto',
       payment_method_collection: 'if_required',
+      subscription_data: { trial_period_days: 30 },
       customer_update: {
         address: 'auto',
         name: 'auto'

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -42,7 +42,7 @@ secondaryMenuItems = [
     name: "Billing",
     newTab: false,
     to: page_billing_path(@account),
-    show: @account&.active_subscription? && Rails.configuration.multiuser_mode
+    show: @account&.payment_processor&.subscribed? && Rails.configuration.multiuser_mode
   },
   {
     name: "Queue",

--- a/app/views/marketing_pages/_cta.html.erb
+++ b/app/views/marketing_pages/_cta.html.erb
@@ -7,7 +7,7 @@
           <span class="block">Ready to set up your website?</span>
         </h2>
         <p class="mt-4 text-lg leading-6 text-gray-925">Have your page published in minutes.</p>
-        <a href="<%= new_registration_path('account') %>" class="mt-6 shadow-xl btn btn-big btn-primary">Get started → </a>
+        <a href="<%= new_registration_path('account') %>" class="mt-6 shadow-xl btn btn-big btn-primary">Start free trial → </a>
       </div>
     </div>
     <ul class="hidden lg:block">

--- a/app/views/marketing_pages/_hero.html.erb
+++ b/app/views/marketing_pages/_hero.html.erb
@@ -27,7 +27,7 @@
         </p>
         <div class="flex items-center mt-9 gap-x-6">
           <a href="<%= new_registration_path('account') %>" class="btn btn-primary btn-big">
-            Make your website
+            Start your free trial
             <%= render :partial => "shared/button_loading_arrow" %>
           </a>
           <%#>

--- a/app/views/marketing_pages/_pricing.html.erb
+++ b/app/views/marketing_pages/_pricing.html.erb
@@ -3,8 +3,8 @@
     <div class="text-center dashboard-container">
       <div class="max-w-3xl mx-auto space-y-2 lg:max-w-none">
         <h2 class="homepage-label">Pricing</h2>
-        <p class="text-4xl font-bold leading-8 tracking-tight text-gray-950 sm:text-5xl md:text-6xl">Free page + newsletter</p>
-        <p class="text-xl text-gray-800">Affordable premium plan for hosting on a custom domain.</p>
+        <p class="text-4xl font-bold leading-8 tracking-tight text-gray-950 sm:text-5xl md:text-6xl">One simple plan</p>
+        <p class="text-xl text-gray-800">Everything you need for your personal website and newsletter.</p>
       </div>
     </div>
   </div>
@@ -12,71 +12,48 @@
     <div class="relative">
       <div class="absolute inset-0 h-3/4"></div>
       <div class="relative z-10 px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
-        <div class="max-w-md mx-auto space-y-4 lg:max-w-5xl lg:grid lg:grid-cols-2 lg:gap-5 lg:space-y-0 ">
+        <div class="max-w-lg mx-auto">
           <div class="flex flex-col overflow-hidden border rounded-lg shadow-lg border-gray-050">
             <div class="px-6 pt-8 bg-white sm:p-10 sm:pb-0">
               <div>
-                <h3 class="badge-secondary" id="tier-basic">
-                  Basic
-                </h3>
+                <h3 class="badge" id="tier-postcard">Postcard</h3>
               </div>
               <div class="flex items-baseline mt-4 text-6xl font-extrabold">
-                Free
+                $4
+                <span class="ml-1 text-2xl font-medium text-gray-500"> per month </span>
               </div>
-              <p class="mt-5 text-lg text-gray-800">Personal homepage + newsletter</p>
+              <p class="mt-5 text-lg text-accent font-semibold">30-day free trial</p>
             </div>
-            <div class="flex flex-col justify-between flex-1 px-6 pt-6 pb-8 space-y-6 bg-white sm:px-10 sm:pt-6">
+            <div class="flex flex-col justify-between flex-1 px-6 pt-6 pb-8 space-y-6 bg-white sm:p-10 sm:pt-6">
               <ul role="list" class="space-y-4">
                 <li class="flex items-start">
                   <div class="flex-shrink-0">
-                    <%= heroicon "check", class: "text-gray-500 h-6 w-6" %>
+                    <%= heroicon "check", class: "h-6 w-6 text-accent" %>
                   </div>
                   <p class="ml-3 text-base text-gray-700">Personalize your homepage</p>
                 </li>
 
-
                 <li class="flex items-start">
                   <div class="flex-shrink-0">
-                    <%= heroicon "check", class: "h-6 w-6 text-gray-500" %>
+                    <%= heroicon "check", class: "h-6 w-6 text-accent" %>
                   </div>
                   <p class="ml-3 text-base text-gray-700">Collect email signups on your page</p>
                 </li>
 
                 <li class="flex items-start">
                   <div class="flex-shrink-0">
-                    <%= heroicon "check", class: "h-6 w-6 text-gray-500" %>
+                    <%= heroicon "check", class: "h-6 w-6 text-accent" %>
                   </div>
                   <p class="ml-3 text-base text-gray-700">Send emails to your subscribers</p>
                 </li>
 
                 <li class="flex items-start">
                   <div class="flex-shrink-0">
-                    <%= heroicon "check", class: "h-6 w-6 text-gray-500" %>
+                    <%= heroicon "check", class: "h-6 w-6 text-accent" %>
                   </div>
                   <p class="ml-3 text-base text-gray-700">Host on postcard.page domain</p>
                 </li>
 
-
-              </ul>
-              <div class="rounded-md shadow">
-                <a href="<%= new_registration_path('account') %>" class="flex items-center justify-center w-full btn btn-primary btn-big" aria-describedby="tier-basic"> Make a free account </a>
-              </div>
-            </div>
-          </div>
-
-          <div class="flex flex-col overflow-hidden border rounded-lg shadow-lg border-gray-050">
-            <div class="px-6 pt-8 bg-white sm:p-10 sm:pb-0">
-              <div>
-                <h3 class="badge" id="tier-premium">Premium</h3>
-              </div>
-              <div class="flex items-baseline mt-4 text-6xl font-extrabold">
-                $4
-                <span class="ml-1 text-2xl font-medium text-gray-500"> per month </span>
-              </div>
-              <p class="mt-5 text-lg text-gray-800">Connect Postcard on your own domain</p>
-            </div>
-            <div class="flex flex-col justify-between flex-1 px-6 pt-6 pb-8 space-y-6 bg-white sm:p-10 sm:pt-6">
-              <ul role="list" class="space-y-4">
                 <li class="flex items-start">
                   <div class="flex-shrink-0">
                     <%= heroicon "check", class: "h-6 w-6 text-accent" %>
@@ -90,17 +67,9 @@
                   </div>
                   <p class="ml-3 text-base text-gray-700">Add custom code, such as analytics</p>
                 </li>
-
-                <li class="flex items-start">
-                  <div class="flex-shrink-0">
-                    <%= heroicon "check", class: "h-6 w-6 text-accent" %>
-                  </div>
-                  <p class="ml-3 text-base text-gray-700">Integrations + API <span class="text-gray-500">(Coming soon)</span></p>
-                </li>
-
               </ul>
               <div class="rounded-md shadow">
-                <a href="<%= new_registration_path('account') %>" class="flex items-center justify-center w-full btn btn-primary btn-big" aria-describedby="tier-premium">Get started </a>
+                <a href="<%= new_registration_path('account') %>" class="flex items-center justify-center w-full btn btn-primary btn-big" aria-describedby="tier-postcard">Start free trial</a>
               </div>
             </div>
           </div>

--- a/app/views/welcome_mailer/how_i_replaced_twitter.html.erb
+++ b/app/views/welcome_mailer/how_i_replaced_twitter.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <p>
-    Hi, I’m Philip - the maker of Postcard! Today I want to share with you how I use Postcard for my own personal website and newsletter at <a href="https://www.philipithomas.com">philipithomas.com</a>.
+    Hi, I’m Philip - the maker of Postcard! Today I want to share with you how I use Postcard for my own personal website and newsletter at <a href="https://philipithomas.postcard.page">philipithomas.postcard.page</a>.
 </p>
 
 <p>
@@ -17,7 +17,7 @@
 </ul>
 
 <p>
-  (Check out a recent example <a href="https://www.philipithomas.com/posts/what-i-m-up-to-december-2022">here</a>)
+  (Check out a recent example <a href="https://philipithomas.postcard.page/posts/what-i-m-up-to-december-2022">here</a>)
 </p>
 
 <p>

--- a/app/views/welcome_mailer/social_networks_over.html.erb
+++ b/app/views/welcome_mailer/social_networks_over.html.erb
@@ -27,7 +27,7 @@
   If you are ready to break the cycle on addictive social networks, try setting up a personal newsletter with Postcard. You can still participate in social networks by sharing posts on those sites. But you can build a newsletter over time that you own. 
 </p>
 
-<p><i>Originally published on <a href="https://www.philipithomas.com/posts/why-i-built-postcard-a-calmer-alternative-to-social-networks">philipithomas.com</a>.</i></p>
+<p><i>Originally published on <a href="https://philipithomas.postcard.page/posts/why-i-built-postcard-a-calmer-alternative-to-social-networks">philipithomas.postcard.page</a>.</i></p>
 
 <% content_for :button_label do %>Write your newsletter<% end %>
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -60,20 +60,20 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "7091306dd0b02a1c02eaadd5138fef97feb5c99ac385b19973467ed117fc84e9",
+      "fingerprint": "e0630695d24b9edc6f4723712fc38efa47e131e46fd11380309fa39f79e3e6c5",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/checkout_controller.rb",
       "line": 10,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Account.friendly.find(params[:page_slug]).checkout_url(page_setup_url(Account.friendly.find(params[:page_slug]), :domain), page_url(Account.friendly.find(params[:page_slug]))), :status => :found, :allow_other_host => true)",
+      "code": "redirect_to(Account.friendly.find(params[:page_slug]).checkout_url(page_url(Account.friendly.find(params[:page_slug])), page_url(Account.friendly.find(params[:page_slug]))), :status => :found, :allow_other_host => true)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "CheckoutController",
         "method": "show"
       },
-      "user_input": "Account.friendly.find(params[:page_slug]).checkout_url(page_setup_url(Account.friendly.find(params[:page_slug]), :domain), page_url(Account.friendly.find(params[:page_slug])))",
+      "user_input": "Account.friendly.find(params[:page_slug]).checkout_url(page_url(Account.friendly.find(params[:page_slug])), page_url(Account.friendly.find(params[:page_slug])))",
       "confidence": "Weak",
       "cwe_id": [
         601

--- a/db/migrate/20260312034422_add_grandfathered_to_accounts.rb
+++ b/db/migrate/20260312034422_add_grandfathered_to_accounts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddGrandfatheredToAccounts < ActiveRecord::Migration[7.1]
+  def up
+    add_column :accounts, :grandfathered, :boolean, default: false, null: false
+    Account.update_all(grandfathered: true)
+  end
+
+  def down
+    remove_column :accounts, :grandfathered
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_10_215212) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_12_034422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_215212) do
     t.bigint "ahoy_signup_visit_id"
     t.bigint "pinned_post_id"
     t.datetime "locked_at"
+    t.boolean "grandfathered", default: false, null: false
     t.index ["confirmation_token"], name: "index_accounts_on_confirmation_token", unique: true
     t.index ["email"], name: "index_accounts_on_email", unique: true
     t.index ["pinned_post_id"], name: "index_accounts_on_pinned_post_id"

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,0 +1,15 @@
+grandfathered_user:
+  name: Grandfathered User
+  email: grandfathered@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(Account, 'password123') %>
+  slug: grandfathered-user
+  grandfathered: true
+  accent_color: "#2c6153"
+
+new_user:
+  name: New User
+  email: newuser@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(Account, 'password123') %>
+  slug: new-user
+  grandfathered: false
+  accent_color: "#2c6153"

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AccountTest < ActiveSupport::TestCase
+  setup do
+    @original_solo_mode = Rails.configuration.solo_mode
+    @original_multiuser_mode = Rails.configuration.multiuser_mode
+  end
+
+  teardown do
+    Rails.configuration.solo_mode = @original_solo_mode
+    Rails.configuration.multiuser_mode = @original_multiuser_mode
+  end
+
+  test "active_subscription? returns true in solo mode" do
+    Rails.configuration.solo_mode = true
+    account = accounts(:new_user)
+    assert account.active_subscription?
+  end
+
+  test "active_subscription? returns false for non-subscribed multiuser account" do
+    Rails.configuration.solo_mode = false
+    account = accounts(:new_user)
+    refute account.active_subscription?
+  end
+
+  test "requires_payment? returns false in solo mode" do
+    Rails.configuration.solo_mode = true
+    account = accounts(:new_user)
+    refute account.requires_payment?
+  end
+
+  test "requires_payment? returns false for grandfathered accounts" do
+    Rails.configuration.solo_mode = false
+    account = accounts(:grandfathered_user)
+    refute account.requires_payment?
+  end
+
+  test "requires_payment? returns true for new non-grandfathered non-subscribed accounts" do
+    Rails.configuration.solo_mode = false
+    account = accounts(:new_user)
+    assert account.requires_payment?
+  end
+
+  test "ever_subscribed? returns false for fresh accounts" do
+    account = accounts(:new_user)
+    refute account.ever_subscribed?
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+require 'rails/test_help'
+
+class ActiveSupport::TestCase
+  fixtures :all
+end


### PR DESCRIPTION
## Summary

- Make hosted Postcard paid-only at **$4/mo with 30-day free trial**, while keeping solo/self-hosted completely free
- **Grandfather existing accounts** — all current accounts are marked `grandfathered: true` and bypass payment requirements
- **Canceled accounts stay active** — `ever_subscribed?` check ensures no lockout after cancellation
- Redirect new signups and unpaid returning users to Stripe Checkout (with trial) across all auth flows (email, OAuth)
- Add `PaymentRequired` concern as a dashboard gate on Pages, Posts, Subscribers, and Showcase controllers
- Replace two-tier Free/Premium pricing page with a single centered $4/mo card highlighting the 30-day free trial
- Update homepage CTAs to "Start your free trial" / "Start free trial"
- Fix billing link visibility for grandfathered accounts (prevents BillingController errors)
- Update philipithomas.com URLs to philipithomas.postcard.page in welcome mailer templates
- Add test infrastructure (test_helper, fixtures) and 6 model tests covering payment logic

## Test plan

- [x] `rails db:migrate` — migration runs, existing accounts get `grandfathered: true`
- [x] `rails test` — all 6 new tests pass
- [ ] Manual: In dev multiuser mode, sign up → redirected to Stripe Checkout (with trial)
- [ ] Manual: Sign in as grandfathered account → goes straight to dashboard
- [ ] Manual: Visit homepage → single pricing card, "$4/month", "30-day free trial"
- [ ] Manual: Check welcome mailer templates reference philipithomas.postcard.page

🤖 Generated with [Claude Code](https://claude.com/claude-code)