### PR TITLE
Allow users to self-delete their accounts in multiuser mode

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -15,7 +15,42 @@ class AccountController < ApplicationController
     end
   end
 
+  def destroy
+    unless Rails.configuration.multiuser_mode
+      return redirect_to page_path(@account), alert: 'Account deletion is not available in solo mode.'
+    end
+    unless @account == current_account
+      return redirect_to page_path(current_account), alert: 'You can only delete your own account.'
+    end
+    unless confirmation_matches?
+      return redirect_to edit_page_path(@account),
+                         alert: "The confirmation didn't match #{@account.postcard_host}, so your account was not deleted."
+    end
+
+    begin
+      cancel_billing
+    rescue Pay::Error => e
+      Rails.logger.error "Failed to cancel billing while deleting account #{@account.id}: #{e.message}"
+      return redirect_to edit_page_path(@account),
+                         alert: 'We could not cancel your billing subscription, so your account was not deleted. Please contact support.'
+    end
+
+    @account.destroy!
+    sign_out @account
+    redirect_to root_path, notice: 'Your account and all of its data have been permanently deleted.'
+  end
+
   private
+
+  def confirmation_matches?
+    params[:confirmation].to_s.strip.downcase == @account.postcard_host.downcase
+  end
+
+  # Destroying Pay::Customer records cascades to Pay::Subscription, whose
+  # before_destroy cancels any active subscription at the payment processor.
+  def cancel_billing
+    @account.pay_customers.each(&:destroy!)
+  end
 
   def account_params
     params.require(:account).permit(:pinned_post_id)

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -29,15 +29,21 @@ class AccountController < ApplicationController
 
     begin
       cancel_billing
-    rescue Pay::Error => e
+    rescue Pay::Error, ::Stripe::StripeError => e
       Rails.logger.error "Failed to cancel billing while deleting account #{@account.id}: #{e.message}"
       return redirect_to edit_page_path(@account),
                          alert: 'We could not cancel your billing subscription, so your account was not deleted. Please contact support.'
     end
 
-    @account.destroy!
+    # Lock the account so sign-in is blocked and the public page goes offline
+    # immediately, then delete the data in the background — established
+    # accounts have too many analytics, subscriber, and email rows to delete
+    # within a request.
+    @account.lock_access!
+    DestroyAccountJob.perform_later(@account)
     sign_out @account
-    redirect_to root_path, notice: 'Your account and all of its data have been permanently deleted.'
+    redirect_to root_path,
+                notice: 'Your account has been deleted. Your page is now offline, and all of your data will be removed shortly.'
   end
 
   private
@@ -46,10 +52,30 @@ class AccountController < ApplicationController
     params[:confirmation].to_s.strip.downcase == @account.postcard_host.downcase
   end
 
-  # Destroying Pay::Customer records cascades to Pay::Subscription, whose
-  # before_destroy cancels any active subscription at the payment processor.
+  # Deleting the customer at Stripe immediately cancels ALL of their
+  # subscriptions, including past_due ones that Pay's cancel helpers skip, and
+  # scrubs the customer's details from Stripe. This must happen synchronously:
+  # Pay's own cancel-on-destroy callback swallows API errors, which could
+  # leave a subscription billing forever with no local record of it.
   def cancel_billing
-    @account.pay_customers.each(&:destroy!)
+    @account.pay_customers.each do |pay_customer|
+      delete_stripe_customer(pay_customer)
+
+      # Keep local records consistent so Pay's cancel-on-destroy callback
+      # doesn't make a doomed API call when DestroyAccountJob removes them.
+      pay_customer.subscriptions.active.each do |subscription|
+        subscription.update!(status: 'canceled', ends_at: Time.current)
+      end
+    end
+  end
+
+  def delete_stripe_customer(pay_customer)
+    return unless pay_customer.processor == 'stripe' && pay_customer.processor_id.present?
+
+    ::Stripe::Customer.delete(pay_customer.processor_id)
+  rescue ::Stripe::InvalidRequestError => e
+    # Already deleted at Stripe — nothing left to cancel.
+    raise unless e.message.include?('No such customer')
   end
 
   def account_params

--- a/app/controllers/accounts/registrations_controller.rb
+++ b/app/controllers/accounts/registrations_controller.rb
@@ -34,6 +34,17 @@ module Accounts
       current_account.enrich if current_account&.persisted?
     end
 
+    # In multiuser mode, account deletion goes through AccountController#destroy,
+    # which requires typed confirmation and cancels billing first.
+    def destroy
+      if Rails.configuration.multiuser_mode
+        redirect_to edit_page_path(current_account),
+                    notice: 'To delete your account, use the "Delete account" section at the bottom of your page settings.'
+      else
+        super
+      end
+    end
+
     def after_sign_up_path_for(account)
       if Rails.configuration.multiuser_mode
         page_checkout_path(account)

--- a/app/javascript/controllers/delete_account_controller.js
+++ b/app/javascript/controllers/delete_account_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Confirmation modal for account deletion. The submit button stays disabled
+// until the typed value matches the account's postcard address.
+export default class extends Controller {
+  static targets = ["modal", "input", "submit"]
+  static values = { expected: String }
+
+  open(e) {
+    e.preventDefault()
+    this.modalTarget.classList.remove("hidden")
+    this.inputTarget.focus()
+  }
+
+  close(e) {
+    if (e) e.preventDefault()
+    this.modalTarget.classList.add("hidden")
+    this.inputTarget.value = ""
+    this.check()
+  }
+
+  closeBackground(e) {
+    if (e.target === this.modalTarget) {
+      this.close()
+    }
+  }
+
+  closeWithKeyboard(e) {
+    if (e.key === "Escape" && !this.modalTarget.classList.contains("hidden")) {
+      this.close()
+    }
+  }
+
+  check() {
+    const matches = this.inputTarget.value.trim().toLowerCase() === this.expectedValue.toLowerCase()
+    this.submitTarget.disabled = !matches
+  }
+}

--- a/app/jobs/destroy_account_job.rb
+++ b/app/jobs/destroy_account_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Permanently deletes an account and all of its data. Deletion happens in a
+# job because the analytics, subscriber, and email tables can hold hundreds of
+# thousands of rows for an established account — far too slow for a request.
+# The account is locked before this job is enqueued, so the page is already
+# offline and sign-in is blocked while deletion runs.
+class DestroyAccountJob < ApplicationJob
+  queue_as :default
+
+  # If the job retries after the account row is already gone, there is nothing
+  # left to do.
+  discard_on ActiveJob::DeserializationError
+
+  def perform(account)
+    account_id = account.id
+
+    purge_analytics(account)
+
+    # Bulk-delete the large tables without per-row callbacks or audits.
+    account.messages.in_batches.delete_all
+    account.subscriptions.in_batches.delete_all
+
+    # Pay does not clean up its records when the owner is destroyed. Billing
+    # was already canceled at Stripe before this job was enqueued.
+    account.pay_customers.each(&:destroy!)
+
+    # Destroys the remainder (posts, domains, imports, feedbacks, attachments)
+    # with normal callbacks.
+    account.destroy!
+
+    purge_audits(account_id)
+  end
+
+  private
+
+  def purge_analytics(account)
+    # Page views recorded for visitors to the account's page. Uses the GIN
+    # jsonb_path_ops index on ahoy_events.properties.
+    Ahoy::Event.where('properties @> ?', { account: account.id }.to_json).in_batches.delete_all
+
+    # The account's own tracked events and visits.
+    Ahoy::Event.where(user_id: account.id).in_batches.delete_all
+    Ahoy::Event.where(visit_id: account.visits.select(:id)).in_batches.delete_all
+    account.visits.in_batches.delete_all
+  end
+
+  def purge_audits(account_id)
+    # Runs last so the audit rows written by the destroys above are removed
+    # too — audit snapshots contain account PII.
+    Audited::Audit.where(auditable_type: 'Account', auditable_id: account_id)
+                  .or(Audited::Audit.where(associated_type: 'Account', associated_id: account_id))
+                  .in_batches.delete_all
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,6 +38,10 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<% if Rails.configuration.multiuser_mode %>
+  <p>Unhappy? <%= link_to "Delete your account", edit_page_path(resource) %> from your page settings.</p>
+<% else %>
+  <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<% end %>
 
 <%= link_to "Back", :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -39,9 +39,9 @@
 <h3>Cancel my account</h3>
 
 <% if Rails.configuration.multiuser_mode %>
-  <p>Unhappy? <%= link_to "Delete your account", edit_page_path(resource) %> from your page settings.</p>
+  <p>Done with Postcard? <%= link_to "Delete your account", edit_page_path(resource) %> from your page settings.</p>
 <% else %>
-  <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+  <p>Done with Postcard? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 <% end %>
 
 <%= link_to "Back", :back %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -3,4 +3,68 @@
   <div class="my-6 mb-12">
     <%= render 'form', account: @account %>
   </div>
+
+  <% if Rails.configuration.multiuser_mode && @account == current_account %>
+    <div
+      class="pt-8 mb-12 border-t border-gray-200"
+      data-controller="delete-account"
+      data-delete-account-expected-value="<%= @account.postcard_host %>">
+      <h2 class="text-lg font-semibold text-red-700">Delete account</h2>
+      <p class="mt-1 text-sm text-gray-600">
+        Permanently delete your account, including your page, posts, subscribers, and analytics. This cannot be undone.
+      </p>
+      <button
+        type="button"
+        class="mt-4 btn text-red-700 bg-white !border-red-700 hover:bg-red-50"
+        data-action="click->delete-account#open">
+        Delete my account&hellip;
+      </button>
+
+      <!-- Confirmation modal -->
+      <div
+        data-delete-account-target="modal"
+        data-action="click->delete-account#closeBackground keyup@window->delete-account#closeWithKeyboard"
+        class="fixed inset-0 flex items-center justify-center hidden min-h-screen overflow-y-auto bg-gray-100/70 min-w-screen"
+        style="z-index: 40;">
+        <div class="w-full max-w-lg max-h-screen p-4">
+          <div class="m-1 bg-white rounded-lg shadow">
+            <div class="p-8">
+              <h2 class="pb-3 text-2xl font-semibold text-center text-gray-925">Delete your account?</h2>
+              <p class="text-sm text-gray-600">
+                This permanently deletes <strong><%= @account.postcard_host %></strong> &mdash; your page, posts,
+                subscribers, custom domains, and analytics. Any active subscription will be canceled.
+                This cannot be undone.
+              </p>
+
+              <%= form_with url: page_account_path(@account), method: :delete, data: { turbo: false } do %>
+                <label for="confirmation" class="block mt-6 text-sm text-gray-600">
+                  Type <span class="font-mono font-semibold select-all"><%= @account.postcard_host %></span> to confirm:
+                </label>
+                <%= text_field_tag :confirmation, nil,
+                  class: 'form-input mt-2',
+                  autocomplete: 'off',
+                  autocapitalize: 'none',
+                  spellcheck: false,
+                  placeholder: @account.postcard_host,
+                  data: { delete_account_target: 'input', action: 'input->delete-account#check' } %>
+
+                <div class="flex items-center justify-between mt-6">
+                  <button type="button" class="link" data-action="click->delete-account#close">
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled
+                    data-delete-account-target="submit"
+                    class="btn text-white bg-red-700 !border-red-700 disabled:opacity-50 disabled:cursor-not-allowed">
+                    Permanently delete
+                  </button>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       resources :draft
     end
     put 'account', to: 'account#update'
+    delete 'account', to: 'account#destroy'
     get 'checkout', to: 'checkout#show', as: :checkout
     get 'billing', to: 'billing#show', as: :billing
   end

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class AccountControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+  include ActiveJob::TestHelper
 
   setup do
     @original_solo_mode = Rails.configuration.solo_mode
@@ -27,16 +28,29 @@ class AccountControllerTest < ActionDispatch::IntegrationTest
     Rails.configuration.multiuser_mode = false
   end
 
-  test 'destroy deletes the account and its associated data with correct confirmation' do
+  test 'destroy locks the account, signs out, and enqueues deletion with correct confirmation' do
     use_multiuser_mode
     sign_in @account
-    @account.posts.create!(subject: 'Hello world', body: 'My first post')
 
-    assert_difference -> { Account.count } => -1, -> { Post.unscoped.count } => -1 do
+    assert_enqueued_with(job: DestroyAccountJob, args: [@account]) do
       delete page_account_path(@account), params: { confirmation: @account.postcard_host }
     end
 
     assert_redirected_to root_path
+    assert @account.reload.access_locked?
+  end
+
+  test 'enqueued deletion removes the account and its associated data' do
+    use_multiuser_mode
+    sign_in @account
+    @account.posts.create!(subject: 'Hello world', body: 'My first post')
+
+    delete page_account_path(@account), params: { confirmation: @account.postcard_host }
+
+    assert_difference -> { Account.count } => -1, -> { Post.unscoped.count } => -1 do
+      perform_enqueued_jobs(only: DestroyAccountJob)
+    end
+
     assert_not Account.exists?(@account.id)
   end
 
@@ -44,7 +58,7 @@ class AccountControllerTest < ActionDispatch::IntegrationTest
     use_multiuser_mode
     sign_in @account
 
-    assert_difference 'Account.count', -1 do
+    assert_enqueued_with(job: DestroyAccountJob) do
       delete page_account_path(@account), params: { confirmation: " #{@account.postcard_host.upcase} " }
     end
 
@@ -55,23 +69,23 @@ class AccountControllerTest < ActionDispatch::IntegrationTest
     use_multiuser_mode
     sign_in @account
 
-    assert_no_difference 'Account.count' do
+    assert_no_enqueued_jobs(only: DestroyAccountJob) do
       delete page_account_path(@account), params: { confirmation: 'wrong-address' }
     end
 
     assert_redirected_to edit_page_path(@account)
-    assert Account.exists?(@account.id)
+    assert_not @account.reload.access_locked?
   end
 
   test 'destroy is not available in solo mode' do
     use_solo_mode
     sign_in @account
 
-    assert_no_difference 'Account.count' do
+    assert_no_enqueued_jobs(only: DestroyAccountJob) do
       delete page_account_path(@account), params: { confirmation: @account.postcard_host }
     end
 
-    assert Account.exists?(@account.id)
+    assert_not @account.reload.access_locked?
   end
 
   test 'cannot destroy another account' do
@@ -79,18 +93,18 @@ class AccountControllerTest < ActionDispatch::IntegrationTest
     other_account = accounts(:grandfathered_user)
     sign_in @account
 
-    assert_no_difference 'Account.count' do
+    assert_no_enqueued_jobs(only: DestroyAccountJob) do
       delete page_account_path(other_account), params: { confirmation: other_account.postcard_host }
     end
 
     assert_redirected_to page_path(@account)
-    assert Account.exists?(other_account.id)
+    assert_not other_account.reload.access_locked?
   end
 
   test 'destroy requires authentication' do
     use_multiuser_mode
 
-    assert_no_difference 'Account.count' do
+    assert_no_enqueued_jobs(only: DestroyAccountJob) do
       delete page_account_path(@account), params: { confirmation: @account.postcard_host }
     end
 

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AccountControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @original_solo_mode = Rails.configuration.solo_mode
+    @original_multiuser_mode = Rails.configuration.multiuser_mode
+    @account = accounts(:new_user)
+    host! Rails.configuration.base_host
+  end
+
+  teardown do
+    Rails.configuration.solo_mode = @original_solo_mode
+    Rails.configuration.multiuser_mode = @original_multiuser_mode
+  end
+
+  def use_multiuser_mode
+    Rails.configuration.solo_mode = false
+    Rails.configuration.multiuser_mode = true
+  end
+
+  def use_solo_mode
+    Rails.configuration.solo_mode = true
+    Rails.configuration.multiuser_mode = false
+  end
+
+  test 'destroy deletes the account and its associated data with correct confirmation' do
+    use_multiuser_mode
+    sign_in @account
+    @account.posts.create!(subject: 'Hello world', body: 'My first post')
+
+    assert_difference -> { Account.count } => -1, -> { Post.unscoped.count } => -1 do
+      delete page_account_path(@account), params: { confirmation: @account.postcard_host }
+    end
+
+    assert_redirected_to root_path
+    assert_not Account.exists?(@account.id)
+  end
+
+  test 'destroy accepts confirmation regardless of case and surrounding whitespace' do
+    use_multiuser_mode
+    sign_in @account
+
+    assert_difference 'Account.count', -1 do
+      delete page_account_path(@account), params: { confirmation: " #{@account.postcard_host.upcase} " }
+    end
+
+    assert_redirected_to root_path
+  end
+
+  test 'destroy does nothing without a matching confirmation' do
+    use_multiuser_mode
+    sign_in @account
+
+    assert_no_difference 'Account.count' do
+      delete page_account_path(@account), params: { confirmation: 'wrong-address' }
+    end
+
+    assert_redirected_to edit_page_path(@account)
+    assert Account.exists?(@account.id)
+  end
+
+  test 'destroy is not available in solo mode' do
+    use_solo_mode
+    sign_in @account
+
+    assert_no_difference 'Account.count' do
+      delete page_account_path(@account), params: { confirmation: @account.postcard_host }
+    end
+
+    assert Account.exists?(@account.id)
+  end
+
+  test 'cannot destroy another account' do
+    use_multiuser_mode
+    other_account = accounts(:grandfathered_user)
+    sign_in @account
+
+    assert_no_difference 'Account.count' do
+      delete page_account_path(other_account), params: { confirmation: other_account.postcard_host }
+    end
+
+    assert_redirected_to page_path(@account)
+    assert Account.exists?(other_account.id)
+  end
+
+  test 'destroy requires authentication' do
+    use_multiuser_mode
+
+    assert_no_difference 'Account.count' do
+      delete page_account_path(@account), params: { confirmation: @account.postcard_host }
+    end
+
+    assert_response :redirect
+    assert_match %r{/accounts/sign_in}, response.location
+  end
+
+  test 'devise registration destroy redirects to settings in multiuser mode' do
+    use_multiuser_mode
+    sign_in @account
+
+    assert_no_difference 'Account.count' do
+      delete account_registration_path
+    end
+
+    assert_redirected_to edit_page_path(@account)
+    assert Account.exists?(@account.id)
+  end
+end

--- a/test/jobs/destroy_account_job_test.rb
+++ b/test/jobs/destroy_account_job_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DestroyAccountJobTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:new_user)
+  end
+
+  test 'deletes the account and bulk-deletable associated data' do
+    visit = @account.visits.create!(visit_token: SecureRandom.uuid, visitor_token: SecureRandom.uuid,
+                                    started_at: Time.current)
+    visit.events.create!(name: 'autotrack', time: Time.current, user_id: @account.id,
+                         properties: { controller: 'pages' })
+
+    # A page view recorded for an anonymous visitor to the account's page
+    visitor_visit = Ahoy::Visit.create!(visit_token: SecureRandom.uuid, visitor_token: SecureRandom.uuid,
+                                        started_at: Time.current)
+    visitor_event = visitor_visit.events.create!(name: 'autotrack', time: Time.current,
+                                                 properties: { account: @account.id, controller: 'public_pages' })
+
+    email_address = EmailAddress.create!(email: 'subscriber@example.com')
+    @account.subscriptions.create!(email_address: email_address, source: :signup, verified_at: Time.current)
+    @account.messages.create!(to: 'subscriber@example.com')
+
+    DestroyAccountJob.perform_now(@account)
+
+    assert_not Account.exists?(@account.id)
+    assert_not Ahoy::Visit.exists?(visit.id)
+    assert_not Ahoy::Event.exists?(visitor_event.id)
+    assert_equal 0, Ahoy::Event.where(user_id: @account.id).count
+    assert_equal 0, Subscription.where(account_id: @account.id).count
+    assert_equal 0, EmailMessage.where(user: @account).count
+    assert_equal 0, Audited::Audit.where(auditable_type: 'Account', auditable_id: @account.id).count
+    assert EmailAddress.exists?(email_address.id), 'shared email addresses should not be deleted'
+  end
+end


### PR DESCRIPTION
## Summary

Adds account self-deletion to the page settings in multiuser mode, with type-to-confirm friction, synchronous billing cancellation, and asynchronous full data cleanup.

### User flow

- **Settings page danger zone** (`pages/edit`): a "Delete account" section shown only in multiuser mode and only to the account owner (not to admins viewing another account's settings).
- **Confirmation modal** (new `delete-account` Stimulus controller): the user must type their postcard address (e.g. `username.postcard.page`) before the delete button enables. Closes on Escape or backdrop click. The confirmation is re-verified server-side (case/whitespace-insensitive).

### Billing cancellation (synchronous, fail-loud)

Pay's cancel-on-destroy callback is unsafe for this: it **swallows API errors** (logs and continues, so a failed Stripe call would delete local records while the subscription keeps billing) and its `active?` check **skips `past_due` subscriptions** (a customer in dunning would keep getting retried after deletion). Instead, `AccountController#destroy` deletes the **Stripe customer** itself — Stripe immediately cancels all of a deleted customer's subscriptions regardless of status, and scrubs their details from Stripe. If the API call fails, deletion aborts with a contact-support message.

### Deletion (asynchronous)

Established accounts can have hundreds of thousands of analytics, subscriber, and email rows; the previous cascade destroyed them row by row (visits → events individually instantiated, audited subscriber destroys) — far too slow for a request. Now:

1. The controller locks the account (`lock_access!`) — sign-in is blocked and the public page 403s immediately — signs the user out, and enqueues `DestroyAccountJob`.
2. The job bulk-deletes in batches: the account's visits/events, **visitor page-view events** (matched via the GIN `jsonb_path_ops` index on `ahoy_events.properties` — these were previously orphaned), email messages, and subscriber records; destroys `Pay::Customer` records (Pay never cleans these up on owner destroy); runs `account.destroy!` for the rest (posts, domains, imports, attachments) with normal callbacks; and finally purges audit snapshots, which contain account PII.

### Also

- Closed a bypass: Devise's default `DELETE /accounts` destroy (no typed confirmation, no billing cleanup) now redirects to this flow in multiuser mode; solo mode unchanged.
- Reworded the cancel-account copy to "Done with Postcard?".

### Tests

`test/controllers/account_controller_test.rb` (8 tests): lock + enqueue + sign-out on success, full data cascade when the job runs, case/whitespace-insensitive confirmation, wrong-confirmation rejection, solo-mode block, other-account block, auth requirement, Devise destroy redirect. `test/jobs/destroy_account_job_test.rb`: bulk deletion of visits, own and visitor analytics events, subscribers, email messages, and audits, while shared `EmailAddress` records survive.

`rails test`, `rails zeitwerk:check`, and `brakeman` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
