### PR TITLE
Tune Solid Queue and domain verification load

### DIFF
--- a/app/jobs/verify_domains_job.rb
+++ b/app/jobs/verify_domains_job.rb
@@ -1,14 +1,51 @@
 # frozen_string_literal: true
 
 class VerifyDomainsJob < ApplicationJob
-  def perform(*_args)
+  RECENT = 'recent'
+  STALE = 'stale'
+  RECENT_WINDOW = 1.week
+  BATCH_SIZE = 25
+
+  def perform(cadence = RECENT)
     # Only run in multi-user mode where custom domains are supported
     return unless Rails.configuration.multiuser_mode
 
-    Domain.where(verified: false).order(Arel.sql('RANDOM()')).each do |domain|
-      domain.update_verification_status
-    rescue StandardError => e
-      Rails.logger.error "Error verifying domain #{domain.name}: #{e}"
+    cadence = cadence.to_s
+    domains_for(cadence).each do |domain|
+      break unless verify_domain(domain, trigger_verification: cadence == STALE)
+    end
+  end
+
+  private
+
+  def verify_domain(domain, trigger_verification:)
+    domain.update_verification_status(trigger_verification: trigger_verification)
+    true
+  rescue Domain::RenderRateLimitError => e
+    Rails.logger.warn "Render rate limit reached while verifying #{domain.domain} (#{domain.id}): #{e.message}"
+    false
+  rescue StandardError => e
+    Rails.logger.error "Error verifying domain #{domain.domain} (#{domain.id}): #{e.class}: #{e.message}"
+    true
+  end
+
+  def domains_for(cadence)
+    unverified_domains(cadence)
+      .order(Arel.sql('RANDOM()'))
+      .limit(BATCH_SIZE)
+  end
+
+  def unverified_domains(cadence)
+    domains = Domain.where(verified: false)
+    cutoff = RECENT_WINDOW.ago
+
+    case cadence
+    when RECENT
+      domains.where('created_at >= ?', cutoff)
+    when STALE
+      domains.where('created_at < ?', cutoff)
+    else
+      raise ArgumentError, "Unknown verification cadence: #{cadence}"
     end
   end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Domain < ApplicationRecord
+  class RenderRateLimitError < StandardError; end
+
   before_save :downcase_domain
   before_destroy :destroy_in_render
   belongs_to :account, touch: true
@@ -69,7 +71,7 @@ class Domain < ApplicationRecord
     )
   end
 
-  def update_verification_status # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+  def update_verification_status(trigger_verification: false) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return if verified
 
     if Rails.env.development? && Domain.localhost_domain?(domain)
@@ -77,11 +79,13 @@ class Domain < ApplicationRecord
       return
     end
 
-    # Trigger DNS verification check with Render
-    Domain.render_service_request("/#{domain}/verify", Net::HTTP::Post)
+    trigger_dns_verification if trigger_verification
 
-    # Then retrieve the updated status
     response = Domain.render_service_request("/#{domain}", Net::HTTP::Get)
+    if response.code == '429'
+      raise RenderRateLimitError,
+            "Render rate limit reached while reading domain #{domain} - code 429 \"#{response.body}\""
+    end
 
     unless response.code == '200'
       raise "Error reading domain #{domain} in Render - code #{response.code} \"#{response.body}\""
@@ -114,6 +118,17 @@ class Domain < ApplicationRecord
   end
 
   private
+
+  def trigger_dns_verification
+    response = Domain.render_service_request("/#{domain}/verify", Net::HTTP::Post)
+    return if response.code == '202'
+
+    message = "Error triggering verification for domain #{domain} in Render - " \
+              "code #{response.code} \"#{response.body}\""
+    raise RenderRateLimitError, message if response.code == '429'
+
+    raise message
+  end
 
   def downcase_domain
     self.domain = domain.downcase

--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -1,11 +1,19 @@
 default: &default
   dispatchers:
-    - polling_interval: 1
+    - polling_interval: 60
       batch_size: 500
+      concurrency_maintenance: false
       recurring_tasks:
-        verify_domains:
+        verify_recent_domains:
           class: VerifyDomainsJob
-          schedule: every 1 minute
+          args:
+            - recent
+          schedule: every 15 minutes
+        verify_stale_domains:
+          class: VerifyDomainsJob
+          args:
+            - stale
+          schedule: "0 4 * * * America/New_York"
         enqueue_analytics_summary_emails:
           class: EnqueueAnalyticsSummaryEmailsJob
           schedule: "0 0 10 * * * America/New_York"
@@ -20,9 +28,9 @@ default: &default
           schedule: "0 3 * * * America/New_York"
   workers:
     - queues: "*"
-      threads: 1
-      processes: 2
-      polling_interval: 1
+      threads: 2
+      processes: 1
+      polling_interval: 30
 
 development:
  <<: *default

--- a/test/config/solid_queue_config_test.rb
+++ b/test/config/solid_queue_config_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'yaml'
+
+class SolidQueueConfigTest < ActiveSupport::TestCase
+  test 'uses low-frequency polling while preserving two-job concurrency' do
+    config = YAML.load_file(Rails.root.join('config/solid_queue.yml'), aliases: true).fetch('default')
+    dispatcher = config.fetch('dispatchers').sole
+    worker = config.fetch('workers').sole
+    recurring_tasks = dispatcher.fetch('recurring_tasks')
+
+    assert_equal 60, dispatcher.fetch('polling_interval')
+    assert_equal false, dispatcher.fetch('concurrency_maintenance')
+    assert_equal 30, worker.fetch('polling_interval')
+    assert_equal 1, worker.fetch('processes')
+    assert_equal 2, worker.fetch('threads')
+
+    assert_equal 'every 15 minutes', recurring_tasks.dig('verify_recent_domains', 'schedule')
+    assert_equal ['recent'], recurring_tasks.dig('verify_recent_domains', 'args')
+    assert_equal '0 4 * * * America/New_York', recurring_tasks.dig('verify_stale_domains', 'schedule')
+    assert_equal ['stale'], recurring_tasks.dig('verify_stale_domains', 'args')
+  end
+end

--- a/test/jobs/verify_domains_job_test.rb
+++ b/test/jobs/verify_domains_job_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+class VerifyDomainsJobTest < ActiveSupport::TestCase
+  setup do
+    @original_multiuser_mode = Rails.configuration.multiuser_mode
+    Rails.configuration.multiuser_mode = true
+  end
+
+  teardown do
+    Rails.configuration.multiuser_mode = @original_multiuser_mode
+  end
+
+  test 'continues checking domains after one verification fails' do
+    attempts = []
+    errors = []
+    failing_domain = fake_domain(1, 'failing.test') do
+      attempts << 'failing.test'
+      raise Net::ReadTimeout
+    end
+    healthy_domain = fake_domain(2, 'healthy.test') { attempts << 'healthy.test' }
+    job = VerifyDomainsJob.new
+
+    job.stub(:domains_for, [failing_domain, healthy_domain]) do
+      Rails.logger.stub(:error, ->(message) { errors << message }) do
+        job.perform
+      end
+    end
+
+    assert_equal ['failing.test', 'healthy.test'], attempts
+    assert_includes errors.first, 'failing.test'
+    assert_includes errors.first, 'Net::ReadTimeout'
+  end
+
+  test 'stops checking stale domains when Render rate limits verification' do
+    attempts = []
+    warnings = []
+    limited_domain = fake_domain(1, 'limited.test') do
+      attempts << 'limited.test'
+      raise Domain::RenderRateLimitError, 'rate limited'
+    end
+    skipped_domain = fake_domain(2, 'skipped.test') { attempts << 'skipped.test' }
+    job = VerifyDomainsJob.new
+
+    job.stub(:domains_for, [limited_domain, skipped_domain]) do
+      Rails.logger.stub(:warn, ->(message) { warnings << message }) do
+        job.perform(VerifyDomainsJob::STALE)
+      end
+    end
+
+    assert_equal ['limited.test'], attempts
+    assert_includes warnings.first, 'limited.test'
+  end
+
+  test 'selects recent and stale unverified domains separately' do
+    recent = create_domain('recent.test', created_at: 1.hour.ago)
+    stale = create_domain('stale.test', created_at: 1.year.ago)
+    create_domain('verified.test', created_at: 1.hour.ago, verified: true)
+    job = VerifyDomainsJob.new
+
+    assert_equal [recent.id], job.send(:domains_for, VerifyDomainsJob::RECENT).pluck(:id)
+    assert_equal [stale.id], job.send(:domains_for, VerifyDomainsJob::STALE).pluck(:id)
+  end
+
+  test 'does not query domains outside multi-user mode' do
+    Rails.configuration.multiuser_mode = false
+
+    Domain.stub(:where, ->(*) { flunk 'domains should not be queried' }) do
+      VerifyDomainsJob.perform_now
+    end
+  end
+
+  private
+
+  def create_domain(name, created_at:, verified: false)
+    Domain.create!(
+      account: accounts(:new_user),
+      domain: name,
+      verified: verified,
+      created_at: created_at,
+      updated_at: created_at
+    )
+  end
+
+  def fake_domain(id, name, &verification)
+    Struct.new(:id, :domain) do
+      define_method(:update_verification_status) do |trigger_verification: false|
+        verification.call(trigger_verification)
+      end
+    end.new(id, name)
+  end
+end

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+class DomainTest < ActiveSupport::TestCase
+  FakeResponse = Struct.new(:code, :body) do
+    def read_body
+      body
+    end
+  end
+
+  setup do
+    @domain = Domain.create!(
+      account: accounts(:new_user),
+      domain: 'example.test',
+      verified: false
+    )
+  end
+
+  test 'reads automatic verification status without manually triggering verification' do
+    requests = []
+    response = FakeResponse.new('200', '{"verificationStatus":"unverified"}')
+
+    Domain.stub(:render_service_request, lambda { |path, method, _body = nil|
+      requests << [path, method]
+      response
+    }) do
+      @domain.update_verification_status
+    end
+
+    assert_equal [['/example.test', Net::HTTP::Get]], requests
+    assert_not @domain.reload.verified?
+  end
+
+  test 'manually triggers verification before reading stale domain status' do
+    requests = []
+    responses = [
+      FakeResponse.new('202', ''),
+      FakeResponse.new('200', '{"verificationStatus":"unverified"}')
+    ]
+
+    Domain.stub(:render_service_request, lambda { |path, method, _body = nil|
+      requests << [path, method]
+      responses.shift
+    }) do
+      @domain.update_verification_status(trigger_verification: true)
+    end
+
+    assert_equal [
+      ['/example.test/verify', Net::HTTP::Post],
+      ['/example.test', Net::HTTP::Get]
+    ], requests
+  end
+
+  test 'raises a rate limit error without making a follow-up request' do
+    requests = []
+    response = FakeResponse.new('429', 'rate limited')
+
+    error = assert_raises(Domain::RenderRateLimitError) do
+      Domain.stub(:render_service_request, lambda { |path, method, _body = nil|
+        requests << [path, method]
+        response
+      }) do
+        @domain.update_verification_status(trigger_verification: true)
+      end
+    end
+
+    assert_equal [['/example.test/verify', Net::HTTP::Post]], requests
+    assert_includes error.message, '429'
+  end
+
+  test 'raises a rate limit error when reading automatic verification status' do
+    requests = []
+    response = FakeResponse.new('429', 'rate limited')
+
+    error = assert_raises(Domain::RenderRateLimitError) do
+      Domain.stub(:render_service_request, lambda { |path, method, _body = nil|
+        requests << [path, method]
+        response
+      }) do
+        @domain.update_verification_status
+      end
+    end
+
+    assert_equal [['/example.test', Net::HTTP::Get]], requests
+    assert_includes error.message, '429'
+  end
+end


### PR DESCRIPTION
## Summary

- reduce idle Solid Queue database polling from one-second loops to a 60-second dispatcher and 30-second worker while preserving two-job concurrency
- check recent unverified domains every 15 minutes without manually retriggering Render, and retry stale domains once daily in capped batches
- stop a verification batch on Render HTTP 429 responses, continue past ordinary per-domain failures, and log the correct domain field
- add job, model, and queue-config regression tests

Render limits custom-domain create/verify POSTs to 50 per hour, so the previous every-minute manual verification could exceed the shared limit with even one unverified domain: https://api-docs.render.com/reference/rate-limiting

## Validation

- `bin/rails test` — 27 runs, 92 assertions, 0 failures
- focused RuboCop — 5 files inspected, no offenses
- verified both recurring schedules parse under the pinned Solid Queue/Fugit versions

## Operational cleanup

The six orphaned production rows for `eifelphotostudio.com`, `paulcancellieri.com`, and `laurencekaptain.com` (apex + `www`) were deleted separately after confirming all six Render custom-domain lookups returned 404.